### PR TITLE
kconfig: add modules to compile test for native

### DIFF
--- a/boards/native/Kconfig
+++ b/boards/native/Kconfig
@@ -24,3 +24,9 @@ config BOARD_NATIVE
     # Various other features (if any)
     select HAS_ETHERNET
     select HAS_MOTOR_DRIVER
+
+    # Needed modules
+    select MOD_NATIVE_DRIVERS
+    select MOD_PERIPH
+
+rsource "drivers/Kconfig"

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -20,4 +20,4 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += random
 endif
 
-USEMODULE += native-drivers
+USEMODULE += native_drivers

--- a/boards/native/drivers/Kconfig
+++ b/boards/native/drivers/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MOD_NATIVE_DRIVERS
+    bool
+    help
+        Drivers for Native board.

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -1,3 +1,3 @@
-MODULE = native-drivers
+MODULE = native_drivers
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -21,3 +21,5 @@ FEATURES_PROVIDED += ssp
 ifeq ($(OS),Linux)
   FEATURES_PROVIDED += periph_spi
 endif
+
+KCONFIG_ADD_CONFIG += $(RIOTCPU)/native/cpu.config

--- a/cpu/native/cpu.config
+++ b/cpu/native/cpu.config
@@ -1,0 +1,2 @@
+# UART is needed by startup.c
+CONFIG_MOD_PERIPH_UART=y

--- a/sys/Kconfig.stdio
+++ b/sys/Kconfig.stdio
@@ -10,10 +10,11 @@ menu "Standard Input/Ouput (STDIO)"
 
 choice
     bool "STDIO implementation"
+    default MOD_STDIO_NATIVE if CPU_ARCH_NATIVE
     default MOD_STDIO_UART
 
 # TODO: Add MOD_STDIO_CDC_ACM, MOD_STDIO_RTT, MOD_SLIPDEV_STDIO,
-# MOD_STDIO_NATIVE and MOD_STDIO_ETHOS
+# MOD_STDIO_ETHOS
 
 config MOD_STDIO_NULL
     bool "Null"
@@ -24,6 +25,10 @@ config MOD_STDIO_UART
     bool "UART"
     depends on HAS_PERIPH_UART
     select MOD_PERIPH_UART
+
+config MOD_STDIO_NATIVE
+    bool "Native"
+    depends on CPU_ARCH_NATIVE
 
 endchoice
 


### PR DESCRIPTION
### Contribution description
This adds the remaining modules needed to compile the test we are using for the native platform.

### Testing procedure
`tests/sys_crypto` should compile and pass for `native`.

### Issues/PRs references
None