### PR TITLE
boards/silabs: add board-specific driver modules to Kconfig

### DIFF
--- a/boards/common/silabs/Kconfig
+++ b/boards/common/silabs/Kconfig
@@ -14,3 +14,11 @@ config MOD_BOARDS_COMMON_SILABS
     bool
     depends on BOARD_COMMON_SILABS
     depends on TEST_KCONFIG
+
+if BOARD_COMMON_SILABS
+
+rsource "drivers/aem/Kconfig"
+rsource "drivers/bc/Kconfig"
+rsource "drivers/pic/Kconfig"
+
+endif # BOARD_COMMON_SILABS

--- a/boards/common/silabs/drivers/aem/Kconfig
+++ b/boards/common/silabs/drivers/aem/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MOD_SILABS_AEM
+    bool
+    help
+        Advanced energy monitor driver.

--- a/boards/common/silabs/drivers/bc/Kconfig
+++ b/boards/common/silabs/drivers/bc/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MOD_SILABS_BC
+    bool
+    help
+        Board controller driver.

--- a/boards/common/silabs/drivers/pic/Kconfig
+++ b/boards/common/silabs/drivers/pic/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MOD_SILABS_PIC
+    bool
+    help
+        Power-and-Interrupt controller.

--- a/boards/slstk3401a/Kconfig
+++ b/boards/slstk3401a/Kconfig
@@ -21,4 +21,8 @@ config BOARD_SLSTK3401A
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_MODECFG
 
+    # needed modules
+    select MOD_SILABS_AEM
+    select MOD_SILABS_BC
+
 source "$(RIOTBOARD)/common/silabs/Kconfig"

--- a/boards/slstk3402a/Kconfig
+++ b/boards/slstk3402a/Kconfig
@@ -21,4 +21,8 @@ config BOARD_SLSTK3402A
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_MODECFG
 
+    # modules needed
+    select MOD_SILABS_AEM
+    select MOD_SILABS_BC
+
 source "$(RIOTBOARD)/common/silabs/Kconfig"

--- a/cpu/efm32/crypto_util.c
+++ b/cpu/efm32/crypto_util.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "crypto_util.h"
 #include "mutex.h"
-
+#if CPU_MODEL_EFM32PG12B500F1024GL125
 static int acqu_count = 0;
 static bool crypto_lock_initialized = false;
 static mutex_t crypto_lock[CRYPTO_COUNT];
@@ -70,3 +70,4 @@ void crypto_release(CRYPTO_TypeDef* dev)
     CMU_ClockEnable(crypto_devs[devno].cmu, false);
     mutex_unlock(&crypto_lock[devno]);
 }
+#endif

--- a/cpu/efm32/families/efm32pg1b/Kconfig
+++ b/cpu/efm32/families/efm32pg1b/Kconfig
@@ -8,6 +8,10 @@ config CPU_FAM_EFM32PG1B
     bool
     select CPU_CORE_CORTEX_M4F
     select CPU_COMMON_EFM32
+    select HAS_PERIPH_CRYPTO_AES
+    select HAS_HW_HASH_SHA1
+    select HAS_HW_HASH_SHA256
+    select MOD_CPU_EFM32PG1B
 
 ## CPU Models
 config CPU_MODEL_EFM32PG1B200F256GM48
@@ -70,3 +74,7 @@ config CPU_MODEL
     default "efm32pg1b200f256im48" if CPU_MODEL_EFM32PG1B200F256IM48
     default "efm32pg1b200f256gm32" if CPU_MODEL_EFM32PG1B200F256GM32
     default "efm32pg1b100f128gm32" if CPU_MODEL_EFM32PG1B100F128GM32
+
+config MOD_CPU_EFM32PG1B
+    bool
+    depends on CPU_FAM_EFM32PG1B


### PR DESCRIPTION
### Contribution description
This adds some missing Silabs drivers modules to Kconfig.

